### PR TITLE
Fix ingots size

### DIFF
--- a/src/main/resources/assets/simpleores/models/item/adamantium_ingot.json
+++ b/src/main/resources/assets/simpleores/models/item/adamantium_ingot.json
@@ -1,18 +1,6 @@
 {
-	"parent": "builtin/generated",
+	"parent": "item/generated",
 	"textures": {
 		"layer0": "simpleores:items/adamantium_ingot"
-	},
-	"display": {
-		"thirdperson": {
-			"rotation": [ 0, 90, -35 ],
-			"translation": [ 0, 1.25, -3.5 ],
-			"scale": [ 0.85, 0.85, 0.85 ]
-		},
-		"firstperson": {
-			"rotation": [ 0, -135, 25 ],
-			"translation": [ 0, 4, 2 ],
-			"scale": [ 1.7, 1.7, 1.7 ]
-		}
 	}
 }

--- a/src/main/resources/assets/simpleores/models/item/copper_ingot.json
+++ b/src/main/resources/assets/simpleores/models/item/copper_ingot.json
@@ -1,18 +1,6 @@
 {
-	"parent": "builtin/generated",
+	"parent": "item/generated",
 	"textures": {
 		"layer0": "simpleores:items/copper_ingot"
-	},
-	"display": {
-		"thirdperson": {
-			"rotation": [ 0, 90, -35 ],
-			"translation": [ 0, 1.25, -3.5 ],
-			"scale": [ 0.85, 0.85, 0.85 ]
-		},
-		"firstperson": {
-			"rotation": [ 0, -135, 25 ],
-			"translation": [ 0, 4, 2 ],
-			"scale": [ 1.7, 1.7, 1.7 ]
-		}
 	}
 }

--- a/src/main/resources/assets/simpleores/models/item/mythril_ingot.json
+++ b/src/main/resources/assets/simpleores/models/item/mythril_ingot.json
@@ -1,18 +1,6 @@
 {
-	"parent": "builtin/generated",
+	"parent": "item/generated",
 	"textures": {
 		"layer0": "simpleores:items/mythril_ingot"
-	},
-	"display": {
-		"thirdperson": {
-			"rotation": [ 0, 90, -35 ],
-			"translation": [ 0, 1.25, -3.5 ],
-			"scale": [ 0.85, 0.85, 0.85 ]
-		},
-		"firstperson": {
-			"rotation": [ 0, -135, 25 ],
-			"translation": [ 0, 4, 2 ],
-			"scale": [ 1.7, 1.7, 1.7 ]
-		}
 	}
 }

--- a/src/main/resources/assets/simpleores/models/item/tin_ingot.json
+++ b/src/main/resources/assets/simpleores/models/item/tin_ingot.json
@@ -1,18 +1,6 @@
 {
-	"parent": "builtin/generated",
+	"parent": "item/generated",
 	"textures": {
 		"layer0": "simpleores:items/tin_ingot"
-	},
-	"display": {
-		"thirdperson": {
-			"rotation": [ 0, 90, -35 ],
-			"translation": [ 0, 1.25, -3.5 ],
-			"scale": [ 0.85, 0.85, 0.85 ]
-		},
-		"firstperson": {
-			"rotation": [ 0, -135, 25 ],
-			"translation": [ 0, 4, 2 ],
-			"scale": [ 1.7, 1.7, 1.7 ]
-		}
 	}
 }


### PR DESCRIPTION
See these screenshots for example: http://imgur.com/a/6RU1m
Adamantium and mythril ingots: normal size (with fix)
Tin and copper ingots: too big size (without fix)